### PR TITLE
add GitHub Actions workflow for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish package
+        run: npx jsr publish

--- a/jsr.json
+++ b/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "@gfargo/tfrogger",
+  "version": "0.1.0",
+  "license": "MIT",
+  "exports": "./dist/cli.js"
+}


### PR DESCRIPTION
Create a new workflow to automate package publishing on push to main. Adds `publish.yml` with steps to checkout code and run `npx jsr publish`. Also introduces `jsr.json` for package configuration with name, version, license, and export path.